### PR TITLE
Fix missing 'each' for JSON::Any with Crystal 0.25

### DIFF
--- a/src/kemal-rest-api/adapters/crystal-db.cr
+++ b/src/kemal-rest-api/adapters/crystal-db.cr
@@ -12,7 +12,7 @@ module KemalRestApi::Adapters
         data = args.as(Hash(String, String))
       else
         data = Hash(String, String).new
-        JSON.parse(args.as(String)).each do |k, v|
+        JSON.parse(args.as(String)).as_h.each do |k, v|
           data[k.to_s] = v.to_s
         end
       end


### PR DESCRIPTION
undefined method 'each' for JSON::Any
is returned since the changes to JSON::Any in Crystal 0.25 (each iterator removed).
This casts the returned JSON object to a Hash before iterating.